### PR TITLE
header

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -25,7 +25,7 @@ class GroupsController < ApplicationController
     def update
      @group = Group.find(params[:id])
      if @group.update(group_params)
-        redirect_to root_path, notice: 'グループを更新しました'
+        redirect_to group_messages_path(@group), notice: 'グループを更新しました'
      else
         render :edit
      end

--- a/app/views/messages/_main_chat.html.haml
+++ b/app/views/messages/_main_chat.html.haml
@@ -2,18 +2,15 @@
     .header
         .left-header
         .left-header__title
-        グループ名
-        %ul.left-header__members
+        = @group.name
+        %left-header__members
         Member：
-        %li.member
-        メンバー名
-        %li.member
-        メンバー名
-        %li.member
-        メンバー名
+        %member
+        - @group.users.each do |user|
+            = user.name
         .right-header
-        .right-header__button
-        Edit
+            .right-header__button
+                = link_to 'Edit', edit_group_path(@group) 
 
     .messages
     -#   .message


### PR DESCRIPTION
WHAT
ヘッダーにグループ名とユーザー名を表示
グループ編集ページへのリンクを設置する
グループ編集後のリダイレクト先を変更

WHY
グループ名とユーザー名を表示するため
editからグループ編集ページへ行くため
編集後のページを表示するため